### PR TITLE
Solve problem of dropping tables

### DIFF
--- a/HospitalMS/Database/HospitalManagementSystemDatabase.sql
+++ b/HospitalMS/Database/HospitalManagementSystemDatabase.sql
@@ -1,16 +1,44 @@
 -- CREATE DATABASE HospitalManagementSystemDatabase;
 
-Drop Table if exists Clinic;
-Drop Table if exists Medical_Stuff;
-Drop Table if exists Room;
-Drop Table if exists Patient;
-Drop Table if exists Case_Report;
-Drop Table if exists Case_Bill;
-Drop Table if exists Medicine;
-Drop Table if exists Appointment;
-Drop Table if exists Stuff_Contacts;
-Drop Table if exists Report_And_Medicine;
+BEGIN
+  EXECUTE IMMEDIATE 'drop TABLE Case_Bill';
+EXCEPTION
+  WHEN OTHERS THEN
+    IF sqlcode != -0942 THEN RAISE; 
+    END IF;
+END; 
 
+/
+
+BEGIN
+  EXECUTE IMMEDIATE 'drop TABLE Appointment';
+EXCEPTION
+  WHEN OTHERS THEN
+    IF sqlcode != -0942 THEN RAISE; 
+    END IF;
+END; 
+
+/
+
+BEGIN
+  EXECUTE IMMEDIATE 'drop TABLE Stuff_Contacts';
+EXCEPTION
+  WHEN OTHERS THEN
+    IF sqlcode != -0942 THEN RAISE; 
+    END IF;
+END; 
+
+/
+
+BEGIN
+  EXECUTE IMMEDIATE 'drop TABLE Report_And_Medicine';
+EXCEPTION
+  WHEN OTHERS THEN
+    IF sqlcode != -0942 THEN RAISE; 
+    END IF;
+END; 
+
+/
 
 Create Table Clinic (
     ClinicName varchar(20) not null primary key,
@@ -124,4 +152,3 @@ Insert into Medicine values(78054, 'Amoxicillin', 100, 5);
 Insert into Medicine values(78065, 'Penicillin', 200.80, 1);
 Insert into Medicine values(78074, 'Methotrexate', 154.60, 3);
 Insert into Medicine values(78089, 'Doxil', 130.5, 4);
-  


### PR DESCRIPTION
Fixes #2 

**PS** :  I've implemented dropping of only 4 tables which are : 
Case_Bill, Appointment, Stuff_Contacts, and Report_And_Medicine
because the other tables cannot be dropped if they are referenced by a FOREIGN KEY constraint
Also, if I dropped all the tables, [this error](https://doc.ispirer.com/sqlways/Output/SQLWays-1-335.html#:~:text=Database%20Migration%20Software-,DROP%20TABLE%20Errors%2C%20ORA%2D02449%3A%20unique%2Fprimary%20keys,by%20a%20FOREIGN%20KEY%20constraint.) would happen.